### PR TITLE
PC-41-ui-crew-adventure

### DIFF
--- a/client/patches/react-native-fast-image+8.6.3.patch
+++ b/client/patches/react-native-fast-image+8.6.3.patch
@@ -1,7 +1,7 @@
 diff --git a/node_modules/react-native-fast-image/RNFastImage.podspec b/node_modules/react-native-fast-image/RNFastImage.podspec
 index db0fada..af624ff 100644
---- a/node_modules/react-native-fast-image/RNFastImage.podspec
-+++ b/node_modules/react-native-fast-image/RNFastImage.podspec
+--- a/client/node_modules/react-native-fast-image/RNFastImage.podspec
++++ b/client/node_modules/react-native-fast-image/RNFastImage.podspec
 @@ -16,6 +16,6 @@ Pod::Spec.new do |s|
    s.source_files  = "ios/**/*.{h,m}"
  


### PR DESCRIPTION
This pull request moves the RNFastImage.podspec file from the node_modules/react-native-fast-image directory to the client/node_modules/react-native-fast-image directory. This change ensures that the podspec file is located in the correct directory for the client project.